### PR TITLE
Support an edge case with a number that is too low compared to the size of the array

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,7 +25,7 @@ module.exports = class Cycled {
 	}
 
 	set index(i) {
-		this._index = (this.size + i) % this.size;
+		this._index = (this.size + (i % this.size)) % this.size;
 	}
 
 	step(steps) {

--- a/test.js
+++ b/test.js
@@ -37,6 +37,9 @@ test('.index', t => {
 	c.index = 2;
 	t.is(c.index, 2);
 	t.is(c.current(), 3);
+	c.index = -7;
+	t.is(c.index, 2);
+	t.is(c.current(), 3);
 });
 
 test('.reversed()', t => {


### PR DESCRIPTION
Before this pull request:

- Setting the `index` to `-7` stores the value `-1` in the `_index` variable
- When trying to get the current value, it would fail as the index is outside of the bounds of the array

Solution:
Before applying a modulo to the `i` variable, we first apply a modulo. Then adding the size of the array makes sure that the variable is above 0. Applying a module one more times makes the result within the expected range.