### PR TITLE
Make it an Array subclass

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,12 +1,12 @@
 'use strict';
 
-module.exports = class Cycled {
+module.exports = class Cycled extends Array {
 	constructor(array) {
 		if (!Array.isArray(array)) {
 			throw new TypeError('Expected an array');
 		}
 
-		this._array = array;
+		super(...array);
 		this._index = 0;
 	}
 
@@ -16,21 +16,17 @@ module.exports = class Cycled {
 		}
 	}
 
-	get size() {
-		return this._array.length;
-	}
-
 	get index() {
 		return this._index;
 	}
 
-	set index(i) {
-		this._index = (this.size + (i % this.size)) % this.size;
+	set index(index) {
+		this._index = (this.length + (index % this.length)) % this.length;
 	}
 
 	step(steps) {
-		this._index = (this.size + this._index + steps) % this.size;
-		return this._array[this._index];
+		this._index = (this.length + this._index + steps) % this.length;
+		return this[this._index];
 	}
 
 	current() {
@@ -52,10 +48,5 @@ module.exports = class Cycled {
 				yield _this.previous();
 			}
 		};
-	}
-
-	// Proxy some useful array methods
-	indexOf(...args) {
-		return this._array.indexOf(...args);
 	}
 };

--- a/readme.md
+++ b/readme.md
@@ -44,6 +44,8 @@ cycled.previous();
 
 ### `cycled = new Cycled(input)`
 
+Initiates an array subclass with the methods documented below. Since it's an array, you can use all the normal array methods on it.
+
 #### input
 
 Type: `Array`
@@ -68,10 +70,6 @@ Returns the previous item.
 
 Returns the item by going the given amount of `steps` through the array. For example, calling `steps(2)` is like calling `next()` twice. You go backward by specifying a negative number.
 
-#### size
-
-Get the size.
-
 #### index
 
 Get or set the current index.
@@ -79,10 +77,6 @@ Get or set the current index.
 #### reversed()
 
 Returns an iterable that will cycle through the array backward indefinitely.
-
-#### indexOf()
-
-Same as `Array#indexOf()`.
 
 
 ## License

--- a/test.js
+++ b/test.js
@@ -26,11 +26,6 @@ test('.step()', t => {
 	t.is(c.step(-2), 1);
 });
 
-test('.size', t => {
-	const c = new Cycled(fixture);
-	t.is(c.size, 3);
-});
-
 test('.index', t => {
 	const c = new Cycled(fixture);
 	t.is(c.index, 0);


### PR DESCRIPTION
That way it gets all the array methods for free. Usually, I don't like subclassing, but in this case, it seems beneficial, as we really do want it to just behave like an array in most cases.

// @lukechilds @tpatel @ThiccCat Thoughts?